### PR TITLE
Always use "dev" environment in PHP's built-in web server

### DIFF
--- a/app/config/router_admin.php
+++ b/app/config/router_admin.php
@@ -19,6 +19,8 @@ if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_N
     return false;
 }
 
+defined('SYMFONY_ENV') || define('SYMFONY_ENV', getenv('SYMFONY_ENV') ?: 'dev');
+
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'admin.php';
 
 require 'admin.php';

--- a/app/config/router_website.php
+++ b/app/config/router_website.php
@@ -19,6 +19,8 @@ if (is_file($_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . $_SERVER['SCRIPT_N
     return false;
 }
 
+defined('SYMFONY_ENV') || define('SYMFONY_ENV', getenv('SYMFONY_ENV') ?: 'dev');
+
 $_SERVER['SCRIPT_FILENAME'] = $_SERVER['DOCUMENT_ROOT'] . DIRECTORY_SEPARATOR . 'website.php';
 
 require 'website.php';


### PR DESCRIPTION
This PR activates the "dev" environment by default when running Sulu on PHP's built-in web server.

Fixes https://github.com/sulu-io/sulu/issues/2069