### PR TITLE
Add 503 status code to maintenance template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu CMF
 ======================
 
+* dev-develop
+    * ENHANCEMENT #637  [SULU-STANDARD]   Added 503 status code to maintenance page
+
 * 1.2.1 (2016-04-26)
     * HOTFIX      #678  [SULU-STANDARD]       Use the new UserProvider for the security
     * HOTFIX      #669  [SULU-STANDARD]       Fixed new deprecations from YAML format

--- a/app/maintenance.php.dist
+++ b/app/maintenance.php.dist
@@ -33,9 +33,10 @@ $lang = substr($_SERVER['HTTP_ACCEPT_LANGUAGE'], 0, 2);
 $locale = array_key_exists($lang, $translations) ? $lang : DEFAULT_LOCALE;
 
 header('Content-Type: text/html; charset=utf-8');
-?>
+http_response_code(503);
 
-<html>
+?><!doctype html>
+<html lang="<?php echo $locale; ?>">
 <head>
     <title><?php echo $translations[$locale]['title']; ?></title>
     <style type="text/css">


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs |  
| License | MIT
| Documentation PR | 

#### What's in this PR?

It sets the 503 status code in the maintenance template.

#### Why?

A maintenance page should be from status code 503.

#### To Do

- [x] added changelog

