### PR TITLE
Example of SF HTTP cache tagging

### DIFF
--- a/app/WebsiteCache.php
+++ b/app/WebsiteCache.php
@@ -11,8 +11,48 @@
 
 require_once __DIR__ . '/WebsiteKernel.php';
 
-use Sulu\Component\HttpCache\HttpCache;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\HttpCache\Store;
+use DTL\Symfony\HttpCacheTagging\Storage\DoctrineCache;
+use DTL\Symfony\HttpCacheTagging\TagManager;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpCache\HttpCache;
+use Doctrine\Common\Cache\PhpFileCache;
+use DTL\Symfony\HttpCacheTagging\TaggingKernel;
+use Symfony\Component\HttpKernel\TerminableInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Sulu\Component\HttpCache\Handler\TagsHandler;
 
-class WebsiteCache extends HttpCache
+class WebsiteCache implements HttpKernelInterface, TerminableInterface
 {
+    private $taggedKernel;
+    private $appKernel;
+
+    public function __construct(HttpKernelInterface $kernel)
+    {
+        $this->appKernel = $kernel;
+        $store = new Store(__DIR__ . '/cache/http_cache');
+        $httpCache = new HttpCache($kernel, $store);
+
+        // our tag storage strategy
+        $tagStorage = new DoctrineCache(new PhpFileCache(__DIR__ . '/cache/http_tags'));
+        $tagManager = new TagManager($tagStorage, $store);
+
+        // now you can procss the request
+        $this->taggedKernel = new TaggingKernel($httpCache, $tagManager, [
+            'tag_encoding' => 'comma-separated',
+            'header_invalidate_tags' => TagsHandler::TAGS_HEADER
+        ]);
+    }
+
+    public function handle(Request $request, $type = HttpKernelInterface::MASTER_REQUEST, $catch = true)
+    {
+        return $this->taggedKernel->handle($request);
+    }
+
+    public function terminate(Request $request, Response $response)
+    {
+        $this->appKernel->terminate($request, $response);
+    }
+
 }

--- a/app/config/sulu.yml
+++ b/app/config/sulu.yml
@@ -107,6 +107,8 @@ sulu_websocket:
         port: %websocket_port%
 
 sulu_content:
+    preview:
+        mode: off
     search:
         mapping:
             Sulu\Bundle\ContentBundle\Document\PageDocument:
@@ -132,14 +134,16 @@ sulu_document_manager:
 sulu_http_cache:
     handlers:
         paths:
-            enabled: true
+            enabled: false
         public:
-            max_age: 240
-            shared_max_age: 240
+            max_age: 100000
+            shared_max_age: 240000
             use_page_ttl: true
             enabled: true
         debug:
-            enabled: %kernel.debug%
+            enabled: true
+        tags:
+            enabled: true
     proxy_client:
         symfony:
             enabled: true

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,9 @@
         "jackalope/jackalope-doctrine-dbal": "~1.2.0",
         "jackalope/jackalope-jackrabbit": "~1.2.0",
         "doctrine/doctrine-cache-bundle": "~1.0",
-        "oro/doctrine-extensions": "^1.0"
+        "oro/doctrine-extensions": "^1.0",
+        "dantleech/sf-http-cache-tagging": "dev-master",
+        "doctrine/cache": "^1.6"
     },
     "require-dev": {
         "sensio/generator-bundle": "~3.0",
@@ -78,5 +80,11 @@
             {"file": "app/config/parameters.yml"},
             {"file": "app/config/phpcr.yml"}
         ]
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url":  "git@github.com:dantleech/sf-http-cache-tagging.git"
+        }
+    ]
 }

--- a/web/website.php
+++ b/web/website.php
@@ -50,14 +50,12 @@ $kernel->loadClassCache();
 
 // Comment this line if you want to use the "varnish" http
 // caching strategy. See http://sulu.readthedocs.org/en/latest/cookbook/caching-with-varnish.html
-if (SYMFONY_ENV != 'dev') {
-    require_once __DIR__ . '/../app/WebsiteCache.php';
-    $kernel = new WebsiteCache($kernel);
+require_once __DIR__ . '/../app/WebsiteCache.php';
+$kernel = new WebsiteCache($kernel);
 
-    // When using the HttpCache, you need to call the method in your front controller
-    // instead of relying on the configuration parameter
-    Request::enableHttpMethodParameterOverride();
-}
+// When using the HttpCache, you need to call the method in your front controller
+// instead of relying on the configuration parameter
+Request::enableHttpMethodParameterOverride();
 
 $request = Request::createFromGlobals();
 $response = $kernel->handle($request);


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Fixed tickets | fixes #issuenum |
| Related issues/PRs | #issuenum |
| License | MIT |
| Documentation PR | sulu-io/sulu-docs#prnum |
#### What's in this PR?

This PR shows an example implementation of the [Symfony HTTP cache library](https://github.com/dantleech/sf-http-cache-tagging).

It allows tag invalidation with the Symfony HTTP Cache.
#### Why?

Although the user can currently use tag invalidation with the Varnish caching server, allowing content to be cached "forever" until it is invalidated, this option is not available with the easier-to-install Symfony (native PHP) HTTP Cache.
#### Example Usage

As in this PR.
