### PR TITLE
Removed namingstrategy for doctrine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu CMF
 ======================
 
+* dev-master
+    * HOTFIX      #693 [SULU-STANDARD]        Removed namingstrategy for doctrine
+
 * 1.2.2 (2016-05-09)
     * HOTFIX      #2375 [SecurityBundle]      Fixed visibility of entries in language dropdown
     * ENHANCEMENT #2373 [MediaBundle]         Added batch indexing for medias

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -62,7 +62,6 @@ doctrine:
         server_version: "%database_version%"
     orm:
         auto_generate_proxy_classes: "%kernel.debug%"
-        naming_strategy: doctrine.orm.naming_strategy.underscore
         auto_mapping: true
 
 # Swiftmailer Configuration


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes (poosible bug for extended sulus)
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu/pull/2380
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the naming-strategy for doctrine.

#### Why?

Doctrine drops columns which name is generated and recreate it if the naming-strategy was changed (was done before 1.2 in https://github.com/sulu/sulu-standard/commit/b712c39ff27050107e1328677213d97d63089cea).