### PR TITLE
Moved markup-bundle to abstract-kernel

### DIFF
--- a/app/AbstractKernel.php
+++ b/app/AbstractKernel.php
@@ -70,6 +70,7 @@ abstract class AbstractKernel extends SuluKernel
             new Sulu\Bundle\HashBundle\SuluHashBundle(),
             new Sulu\Bundle\CustomUrlBundle\SuluCustomUrlBundle(),
             new Sulu\Bundle\RouteBundle\SuluRouteBundle(),
+            new Sulu\Bundle\MarkupBundle\SuluMarkupBundle(),
             new DTL\Bundle\PhpcrMigrations\PhpcrMigrationsBundle(),
             new Dubture\FFmpegBundle\DubtureFFmpegBundle(),
 

--- a/app/WebsiteKernel.php
+++ b/app/WebsiteKernel.php
@@ -34,7 +34,6 @@ class WebsiteKernel extends \AbstractKernel
         $bundles = parent::registerBundles();
         $bundles[] = new Symfony\Cmf\Bundle\RoutingBundle\CmfRoutingBundle();
         $bundles[] = new Client\Bundle\WebsiteBundle\ClientWebsiteBundle();
-        $bundles[] = new Sulu\Bundle\MarkupBundle\SuluMarkupBundle();
 
         return $bundles;
     }


### PR DESCRIPTION
This PR moves the markup-bundle to the abstract-kernel. This will be needed in https://github.com/sulu/sulu/pull/2402