### PR TITLE
Add host and prefix automatically for route generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
+    * ENHANCEMENT #2484 [WebsiteBundle]   Add host and prefix automatically for route generator
     * ENHANCEMENT #637  [SULU-STANDARD]   Added 503 status code to maintenance page
 
 * 1.2.3 (2016-06-01)

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,6 +1,16 @@
 # Upgrade
 
-## dev-develo
+## dev-develop
+
+### Twig variable `request.routeParameters` removed
+
+The `request.routeParameters` variable has been removed because it is not longer required when generate an url.
+
+**Before**
+
+```twig
+{{ path('client_website.search', request.routeParameters) }}
+```
 
 ### Composer autoloader
 

--- a/composer.lock
+++ b/composer.lock
@@ -3865,12 +3865,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sulu/sulu.git",
-                "reference": "c569905e4b00109b20b0792ce9c1f65e0a5d9443"
+                "reference": "370d795254f3dbeecf2af88a3f3bd32fb30a6d50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sulu/sulu/zipball/c569905e4b00109b20b0792ce9c1f65e0a5d9443",
-                "reference": "c569905e4b00109b20b0792ce9c1f65e0a5d9443",
+                "url": "https://api.github.com/repos/sulu/sulu/zipball/370d795254f3dbeecf2af88a3f3bd32fb30a6d50",
+                "reference": "370d795254f3dbeecf2af88a3f3bd32fb30a6d50",
                 "shasum": ""
             },
             "require": {
@@ -3963,7 +3963,7 @@
                 "core",
                 "sulu"
             ],
-            "time": "2016-06-15 06:57:24"
+            "time": "2016-06-15 12:23:02"
         },
         {
             "name": "sulu/theme-bundle",

--- a/src/Client/Bundle/WebsiteBundle/Resources/themes/default/views/master.html.twig
+++ b/src/Client/Bundle/WebsiteBundle/Resources/themes/default/views/master.html.twig
@@ -40,7 +40,7 @@
                         </div>
                     </div>
                     <div class="col-lg-3">
-                        <form action="{{ path('website_search', request.routeParameters) }}" method="GET">
+                        <form action="{{ path('website_search') }}" method="GET">
                             <input name="q" type="text" placeholder="Search" />
                             <input type="submit" value="Go" />
                         </form>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| PR | sulu/sulu#2484
| License | MIT

#### What's in this PR?

Add `request.routeParameters` (host, prefix) automatically for route generator.

#### Why?

When you render your own template and have no `request.routeParameters` you needed to call the request analyzer or create a twig extension which will load from the current request routeParameters.

#### Example Usage

```twig
{{ path('client_website.search') }}
{{ url('client_website.search') }}
```