### PR TITLE
removed http cache paths-handler from configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu CMF
 ======================
 
+* dev-develop
+    * BUGFIX      #726  [SULU-STANDARD]       Removed HTTP Cache PathsHandler configuration
+
 * 1.3.0-RC3 (2016-08-08)
     * BUGFIX      #2760 [MediaBundle]         Added missing locale to media move action
     * ENHANCEMENT #2759 [ContentBundle]       Fixed ok button translation for smart content overlay

--- a/app/config/sulu.yml
+++ b/app/config/sulu.yml
@@ -130,8 +130,6 @@ sulu_document_manager:
 
 sulu_http_cache:
     handlers:
-        paths:
-            enabled: true
         public:
             max_age: 240
             shared_max_age: 240


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/sulu/sulu/pull/2648
| License | MIT
| Documentation PR | -

#### What's in this PR?

This PR removes the HTTP Cache PathsHandler configuration from the sulu.yml file.

#### Why?

The HTTP Cache integration got refactored and the PathsHandler got removed.
(https://github.com/sulu/sulu/pull/2648)