### PR TITLE
Removed composer update (was already removed in sulu/sulu)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -174,9 +174,6 @@ The `request.routeParameters` variable has been removed because it is not longer
 {{ path('client_website.search', request.routeParameters) }}
 ```
 
-### Composer autoloader
-
-Run `composer update` to rebuild the autoloader.
 ## 1.2.7
 
 ### Default Country


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | 
| Related issues/PRs | 
| License | MIT
| Documentation PR | 

#### What's in this PR?

Removed the "Composer autoloader" section from the upgrade instructions for 1.3.0-RC1.

#### Why?

Not needed as composer update or install is executed anyway during an update. Was already removed in sulu/sulu.