### PR TITLE
Refactored the image-formats of the default theme to meet new image-formats version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu CMF
 ======================
 
+* dev-develop
+    * ENAHCNEMENT #738 [SULU-STANDARD]        Refactored the image-formats of the default theme to meet new image-formats version
+
 * 1.3.0 (2016-08-11)
     * FEATURE     #2680 [AdminBundle]         Changed the login background for the release
     * BUGFIX      #2764 [MediaBundle]         Fixed type filter for media content type

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "sulu/sulu": "dev-develop",
-        "sulu/theme-bundle": "1.0.*",
+        "sulu/theme-bundle": "dev-develop",
         "symfony-cmf/core-bundle": "1.2.*",
         "dantleech/phpcr-migrations-bundle": "0.1.*",
 

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "1a13d7c1f934f98a964319891b44709d",
-    "content-hash": "c86c9fd5c45524dea66ffea49771741f",
+    "hash": "3769131a7472bed5ed28cc6059f9e9f5",
+    "content-hash": "065c5636efd4861865398b0271f9a5c0",
     "packages": [
         {
             "name": "aferrandini/urlizer",
@@ -3864,12 +3864,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sulu/sulu.git",
-                "reference": "87db5be1fbfa63441484bd08fd82d9d3172a043f"
+                "reference": "c8e387241d1e69ca03fb03ae765bbaf0d082d729"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sulu/sulu/zipball/87db5be1fbfa63441484bd08fd82d9d3172a043f",
-                "reference": "87db5be1fbfa63441484bd08fd82d9d3172a043f",
+                "url": "https://api.github.com/repos/sulu/sulu/zipball/c8e387241d1e69ca03fb03ae765bbaf0d082d729",
+                "reference": "c8e387241d1e69ca03fb03ae765bbaf0d082d729",
                 "shasum": ""
             },
             "require": {
@@ -3964,21 +3964,21 @@
                 "core",
                 "sulu"
             ],
-            "time": "2016-08-23 10:12:13"
+            "time": "2016-08-24 09:31:03"
         },
         {
             "name": "sulu/theme-bundle",
-            "version": "1.0.0",
+            "version": "dev-develop",
             "target-dir": "Sulu/Bundle/ThemeBundle",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sulu/SuluThemeBundle.git",
-                "reference": "300e53ec9607771c59ec870124425dd426b08f9b"
+                "reference": "27a29326852b9fd7663f4218ad99765a0045438f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sulu/SuluThemeBundle/zipball/300e53ec9607771c59ec870124425dd426b08f9b",
-                "reference": "300e53ec9607771c59ec870124425dd426b08f9b",
+                "url": "https://api.github.com/repos/sulu/SuluThemeBundle/zipball/27a29326852b9fd7663f4218ad99765a0045438f",
+                "reference": "27a29326852b9fd7663f4218ad99765a0045438f",
                 "shasum": ""
             },
             "require": {
@@ -4014,7 +4014,7 @@
                 "sulu",
                 "theme"
             ],
-            "time": "2016-07-22 08:47:40"
+            "time": "2016-08-24 09:31:18"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -4175,7 +4175,7 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony CMF community",
+                    "name": "Symfony CMF Community",
                     "homepage": "https://github.com/symfony-cmf/Routing/contributors"
                 }
             ],
@@ -6045,16 +6045,16 @@
         },
         {
             "name": "dantleech/glob-finder",
-            "version": "0.3",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dantleech/glob.git",
-                "reference": "d810c78826ed5140f941269c7ecf5f3ef7703df0"
+                "reference": "1f618e6b77a5de4c6b0538d82572fe19cbb1c446"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dantleech/glob/zipball/d810c78826ed5140f941269c7ecf5f3ef7703df0",
-                "reference": "d810c78826ed5140f941269c7ecf5f3ef7703df0",
+                "url": "https://api.github.com/repos/dantleech/glob/zipball/1f618e6b77a5de4c6b0538d82572fe19cbb1c446",
+                "reference": "1f618e6b77a5de4c6b0538d82572fe19cbb1c446",
                 "shasum": ""
             },
             "require-dev": {
@@ -6068,11 +6068,6 @@
                 "doctrine/phpcr-odm": "To enable support for the PHPCR ODM documents"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "DTL\\Glob\\": "lib/DTL/Glob"
@@ -6090,7 +6085,7 @@
             ],
             "description": "Library offering object location from hierarchrical persistent storage systems using globs",
             "homepage": "http://www.github.com/dantleech/glob",
-            "time": "2015-03-18 08:13:31"
+            "time": "2016-08-23 14:48:07"
         },
         {
             "name": "instaclick/php-webdriver",
@@ -6152,48 +6147,49 @@
         },
         {
             "name": "phpcr/phpcr-shell",
-            "version": "1.0.0-beta1",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpcr/phpcr-shell.git",
-                "reference": "c60a899148a150f8dc88cb3208d9be40a1450ff8"
+                "reference": "8af797e455c433e95f0ffb66ee7f2efd02faf19e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpcr/phpcr-shell/zipball/c60a899148a150f8dc88cb3208d9be40a1450ff8",
-                "reference": "c60a899148a150f8dc88cb3208d9be40a1450ff8",
+                "url": "https://api.github.com/repos/phpcr/phpcr-shell/zipball/8af797e455c433e95f0ffb66ee7f2efd02faf19e",
+                "reference": "8af797e455c433e95f0ffb66ee7f2efd02faf19e",
                 "shasum": ""
             },
             "require": {
-                "dantleech/glob-finder": "~0.1",
+                "dantleech/glob-finder": "~1.0",
                 "jackalope/jackalope": "~1.1",
                 "phpcr/phpcr": "~2.1",
                 "phpcr/phpcr-utils": "~1.2",
-                "symfony/console": "~2.3",
-                "symfony/dependency-injection": "~2.3",
-                "symfony/finder": "~2.3",
-                "symfony/serializer": "~2.3",
-                "symfony/yaml": "~2.3"
+                "symfony/console": "~2.8|~3.0",
+                "symfony/dependency-injection": "~2.8|~3.0",
+                "symfony/expression-language": "~2.8|~3.0",
+                "symfony/finder": "~2.8|~3.0",
+                "symfony/serializer": "~2.8|~3.0",
+                "symfony/yaml": "~2.8|~3.0"
             },
             "conflict": {
                 "doctrine/phpcr-bundle": "<=1.2.1"
             },
             "require-dev": {
-                "behat/behat": "~3.0.0",
+                "behat/behat": "~3.0",
                 "jackalope/jackalope-doctrine-dbal": "~1.1",
-                "jackalope/jackalope-fs": "dev-master",
                 "jackalope/jackalope-jackrabbit": "~1.1",
-                "phpspec/phpspec": "2.0",
-                "phpunit/phpunit": "~3.7.28",
-                "symfony/filesystem": "~2.3",
-                "symfony/process": "~2.3",
-                "symfony/symfony": "2.6"
+                "phpspec/phpspec": "3.0",
+                "phpunit/phpunit": "~4.0",
+                "symfony/symfony": "~2.8|~3.0"
             },
             "suggest": {
                 "jackalope/jackalope-doctrine-dbal": "To connect to jackalope doctrine-dbal",
                 "jackalope/jackalope-jackrabbit": "To connect to jackalope jackrabbit",
                 "jackalope/jackalope-jackrabbit-fs": "To connect to jackalope jackalope-fs"
             },
+            "bin": [
+                "bin/phpcrsh"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -6216,7 +6212,7 @@
                 }
             ],
             "description": "Shell for PHPCR",
-            "time": "2015-01-05 11:11:50"
+            "time": "2016-08-23 16:07:50"
         },
         {
             "name": "sensio/generator-bundle",
@@ -6330,6 +6326,7 @@
     "minimum-stability": "stable",
     "stability-flags": {
         "sulu/sulu": 20,
+        "sulu/theme-bundle": 20,
         "zendframework/zendsearch": 20,
         "massive/search-bundle": 20,
         "phpcr/phpcr-shell": 10,

--- a/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
+++ b/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
@@ -1,17 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <formats xmlns="http://schemas.sulu.io/media/formats"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.0.xsd">
-    <format>
-        <name>640x480</name>
-        <commands>
-            <command>
-                <action>resize</action>
-                <parameters>
-                    <parameter name="x">640</parameter>
-                    <parameter name="y">480</parameter>
-                </parameters>
-            </command>
-        </commands>
+          xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.1.xsd">
+    <format key="640x480">
+        <scale x="640" y="480"/>
     </format>
 </formats>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | https://github.com/sulu/sulu/pull/2845
| License | MIT
| Documentation PR | -

#### What's in this PR?

The image-formats configuration file of the website-bundle was adapted to meet the requirements of the new version for defining image-formats.

#### Why?

The PR https://github.com/sulu/sulu/pull/2845 introduced a new version for defining image-formats. As sulu-standard want's to provide a current, up-to-date example on how a simple project using sulu looks like, the configuration files had to updated.