### PR TITLE
Added title to header image format and made use of 640x480 format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
+    * ENAHCNEMENT #745 [SULU-STANDARD]        Added title to header image format and made use of 640x480 format
     * ENAHCNEMENT #738 [SULU-STANDARD]        Refactored the image-formats of the default theme to meet new image-formats version
 
 * 1.3.0 (2016-08-11)

--- a/app/Resources/pages/default.xml.dist
+++ b/app/Resources/pages/default.xml.dist
@@ -40,6 +40,14 @@
             </properties>
         </section>
 
+        <property name="headerimage" type="media_selection">
+            <tag name="sulu.search.field" role="image" index="false"/>
+            <meta>
+                <title lang="de">Headerbild</title>
+                <title lang="en">Header image</title>
+            </meta>
+        </property>
+
         <property name="links" type="internal_links">
             <meta>
                 <title lang="de">Interne Links</title>

--- a/composer.lock
+++ b/composer.lock
@@ -3864,12 +3864,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/sulu/sulu.git",
-                "reference": "68fe87e12b3c029ed6b77d36c98fe38d80f0ca5c"
+                "reference": "4d2cbeb50befee81c29820a481b2478cd11dc37c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sulu/sulu/zipball/68fe87e12b3c029ed6b77d36c98fe38d80f0ca5c",
-                "reference": "68fe87e12b3c029ed6b77d36c98fe38d80f0ca5c",
+                "url": "https://api.github.com/repos/sulu/sulu/zipball/4d2cbeb50befee81c29820a481b2478cd11dc37c",
+                "reference": "4d2cbeb50befee81c29820a481b2478cd11dc37c",
                 "shasum": ""
             },
             "require": {
@@ -3964,7 +3964,7 @@
                 "core",
                 "sulu"
             ],
-            "time": "2016-09-07 05:45:48"
+            "time": "2016-09-07 07:54:57"
         },
         {
             "name": "sulu/theme-bundle",
@@ -4175,7 +4175,7 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony CMF community",
+                    "name": "Symfony CMF Community",
                     "homepage": "https://github.com/symfony-cmf/Routing/contributors"
                 }
             ],

--- a/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
+++ b/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
@@ -6,6 +6,8 @@
         <meta>
             <title lang="en">Header image</title>
             <title lang="de">Headerbild</title>
+            <title lang="fr">Image l'en-tête</title>
+            <title lang="nl">Header afbeelding</title>
         </meta>
         <scale x="640" y="480"/>
     </format>

--- a/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
+++ b/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
@@ -3,6 +3,10 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://schemas.sulu.io/media/formats http://schemas.sulu.io/media/formats-1.1.xsd">
     <format key="640x480">
+        <meta>
+            <title lang="en">Header image</title>
+            <title lang="de">Headerbild</title>
+        </meta>
         <scale x="640" y="480"/>
     </format>
 </formats>

--- a/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/default.html.twig
+++ b/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/default.html.twig
@@ -8,11 +8,16 @@
             <div class="col-lg-12">
                 <h1 class="page-header" property="title">{{ content.title }}</h1>
 
-                Images (excerpt):
+                {% if content.headerimage|length > 0 %}
+                    <img src="{{ content.headerimage[0].thumbnails['640x480'] }}" alt="{{ content.headerimage[0].title }}"/>
+                {% endif %}
+
                 {% if extension.excerpt.images|length > 0 %}
+                    Images (excerpt):
                     <img src="{{ extension.excerpt.images[0].thumbnails['50x50'] }}" alt="{{ extension.excerpt.images[0].title }}"/>
                 {% endif %}
                 {% if extension.excerpt.icon|length > 0 %}
+                    Icons (excerpt):
                     <img src="{{ extension.excerpt.icon[0].thumbnails['50x50'] }}" alt="{{ extension.excerpt.icon[0].title }}"/>
                 {% endif %}
 


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | -
| Related issues/PRs | -
| License | MIT
| Documentation PR | -

#### What's in this PR?

The new method of defining image-formats allows for defining readable translations for an image format. This PR adds titles to the image-formats in sulu-standard.
