### PR TITLE
fixed category access in default twig template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
+    * BUGFIX      #751 [SULU-STANDARD]        Fixed category access in default twig template
     * ENAHCNEMENT #745 [SULU-STANDARD]        Added title to header image format and made use of 640x480 format
     * ENAHCNEMENT #738 [SULU-STANDARD]        Refactored the image-formats of the default theme to meet new image-formats version
 

--- a/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/default.html.twig
+++ b/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/default.html.twig
@@ -25,11 +25,11 @@
                 <div property="article">{{ content.article }}</div>
                 {% endautoescape %}
 
-                {% if content.ext.excerpt.categories is defined %}
+                {% if extension.excerpt.categories is defined %}
                     <h3>Categories</h3>
 
                     <ul property="categories">
-                        {% for category in content.ext.excerpt.categories %}
+                        {% for category in extension.excerpt.categories %}
                             <li>{{ category.id }} - {{ category.name }}</li>
                         {% endfor %}
                     </ul>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #740
| Related issues/PRs | none
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR changes the way the categories are accessed in the twig template.