### PR TITLE
removed sessions from context specific configurations

### DIFF
--- a/app/config/admin/sulu.yml
+++ b/app/config/admin/sulu.yml
@@ -63,7 +63,3 @@ sulu_contact:
 sulu_collaboration:
     entity_cache: doctrine_cache.providers.sulu_collaboration_entity
     connection_cache: doctrine_cache.providers.sulu_collaboration_connection
-
-sulu_document_manager:
-    default_session: default
-    live_session: live

--- a/app/config/sulu.yml
+++ b/app/config/sulu.yml
@@ -114,6 +114,7 @@ sulu_document_manager:
             workspace: "%phpcr_workspace%_live"
             username: "%phpcr_user%"
             password: "%phpcr_pass%"
+
     mapping:
         page:
             class: Sulu\Bundle\ContentBundle\Document\PageDocument

--- a/app/config/website/sulu.yml
+++ b/app/config/website/sulu.yml
@@ -17,6 +17,3 @@ cmf_routing:
     dynamic:
         enabled: true
         route_provider_service_id: sulu_website.provider.content
-
-sulu_document_manager:
-    default_session: live


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | https://github.com/sulu/sulu/pull/3014
| License | MIT
| Documentation PR | none

#### What's in this PR?

This PR removes the context specific configurations. The session can theoretically still be changed, but practically it is still not possible to do because of https://github.com/phpcr/phpcr-migrations/issues/4

#### Why?

Because with sulu/sulu#3014 they are not necessary anymore.
