### PR TITLE
Update example.html.twig with better check if view has elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
-    * ENHANCEMENT #780  [SULU-STANDARD]         Updated example template
+    * ENHANCEMENT #788  [SULU-STANDARD]         Updated example template
     * ENHANCEMENT #779  [SULU-STANDARD]         Removed exception-controller from config
     * ENHANCEMENT #771  [SULU-STANDARD]         Removed generator-bundle
     * BUGFIX      #773  [SULU-STANDARD]         Removed acl configuration

--- a/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/example.html.twig
+++ b/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/example.html.twig
@@ -40,7 +40,7 @@
                         <p property="single">{{ block.single }}</p>
                     {% elseif block.type == 'editor_image' %}
                         {% set viewBlock = view.blocks[loop.index - 1] %}
-                        {% if viewBlock.images.ids is not null %}
+                        {% if viewBlock.images.ids|length > 0 %}
                             {% set displayOption = viewBlock.images.displayOption|default('top') %}
                             {% if displayOption == 'top' %}
                                 {% set float = 'none' %}

--- a/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/example.html.twig
+++ b/src/Client/Bundle/WebsiteBundle/Resources/themes/default/templates/example.html.twig
@@ -40,7 +40,7 @@
                         <p property="single">{{ block.single }}</p>
                     {% elseif block.type == 'editor_image' %}
                         {% set viewBlock = view.blocks[loop.index - 1] %}
-                        {% if viewBlock.images is not null %}
+                        {% if viewBlock.images.ids is not null %}
                             {% set displayOption = viewBlock.images.displayOption|default('top') %}
                             {% if displayOption == 'top' %}
                                 {% set float = 'none' %}


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | none
| Related issues/PRs | none
| License | MIT
| Documentation PR | sulu-io/sulu-docs#prnum

#### What's in this PR?

Modified check in `example.html.twig?` for view elements. Now the check returns `true` if elements available since the previous check alltimes returns `true`.

#### Why?

Because the previous check makes no sense. The old check returns alltimes `true`.
