### PR TITLE
added image format which was not defined

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "sensio/framework-extra-bundle": "^3.0.2",
         "incenteev/composer-parameter-handler": "~2.0",
         "sulu/sulu": "dev-develop",
-        "sulu/theme-bundle": "1.1.*",
+        "sulu/theme-bundle": "dev-develop",
         "dantleech/phpcr-migrations-bundle": "0.1.*",
 
         "nelmio/alice": "~1.7",

--- a/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
+++ b/src/Client/Bundle/WebsiteBundle/Resources/themes/default/config/image-formats.xml
@@ -11,4 +11,13 @@
         </meta>
         <scale x="640" y="480"/>
     </format>
+    <format key="50x50">
+        <meta>
+            <title lang="en">Small thumbnail</title>
+            <title lang="de">Kleines Thumbnail</title>
+            <title lang="fr">Image miniature</title>
+            <title lang="nl">Kleine thumbnail</title>
+        </meta>
+        <scale x="50" y="50"/>
+    </format>
 </formats>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | ---
| Related issues/PRs | https://github.com/sulu/sulu/pull/3040
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adds an image format which was used in a template in this project.

#### Why?

It was working previously because the image format existed in sulu/sulu, but it was removed there.