### PR TITLE
removed automation-bundle from default installation

### DIFF
--- a/app/AbstractKernel.php
+++ b/app/AbstractKernel.php
@@ -46,9 +46,6 @@ abstract class AbstractKernel extends SuluKernel
             // massive
             new Massive\Bundle\SearchBundle\MassiveSearchBundle(),
 
-            // php-task
-            new Task\TaskBundle\TaskBundle(),
-
             // sulu
             new Sulu\Bundle\SearchBundle\SuluSearchBundle(),
             new Sulu\Bundle\PersistenceBundle\SuluPersistenceBundle(),
@@ -69,7 +66,6 @@ abstract class AbstractKernel extends SuluKernel
             new Sulu\Bundle\CustomUrlBundle\SuluCustomUrlBundle(),
             new Sulu\Bundle\RouteBundle\SuluRouteBundle(),
             new Sulu\Bundle\MarkupBundle\SuluMarkupBundle(),
-            new Sulu\Bundle\AutomationBundle\SuluAutomationBundle(),
             new DTL\Bundle\PhpcrMigrations\PhpcrMigrationsBundle(),
             new Dubture\FFmpegBundle\DubtureFFmpegBundle(),
 

--- a/app/config/admin/routing.yml
+++ b/app/config/admin/routing.yml
@@ -76,16 +76,6 @@ sulu_website_api:
     type: rest
     prefix: /admin/api
 
-sulu_automation_api:
-    type: rest
-    resource: "@SuluAutomationBundle/Resources/config/routing_api.xml"
-    prefix: /admin/api
-
-sulu_automation:
-    type: rest
-    resource: "@SuluAutomationBundle/Resources/config/routing.xml"
-    prefix: /admin/automation
-
 sulu_websocket:
     type: rest
     resource: "@SuluWebsocketBundle/Resources/config/routing.yml"

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,7 @@
         "doctrine/doctrine-cache-bundle": "~1.0",
         "oro/doctrine-extensions": "^1.0",
 
-        "sulu/document-manager": "@dev",
-        "php-task/task-bundle": "@dev",
-        "php-task/php-task": "@dev"
+        "sulu/document-manager": "@dev"
     },
     "require-dev": {
         "sensio/generator-bundle": "~3.0",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | no
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #3181
| Related issues/PRs | https://github.com/sulu/sulu/issues/3181
| License | MIT
| Documentation PR | ---

#### What's in this PR?

This PR adapts to the changes which were made, because the `SuluAutomationBundle` has been extracted from the standard.