### PR TITLE
Bugfix/Added ClientWebsiteBundle to Assetic configuration and sulu/document-manager to composer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
-	* BUGFIX      #XXX  [SULU-STANDARD]			Added 'ClientWebsiteBundle' to default bundles of Assetic configuration.
+    * BUGFIX      #XXX  [SULU-STANDARD]			Added 'ClientWebsiteBundle' to default bundles of Assetic configuration.
     * ENHANCEMENT #795  [SULU-STANDARD]         Updated dependencies and fixed symfony3 deprecations
 
 * 1.5.3 (2017-04-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
-    * BUGFIX      #816  [SULU-STANDARD]			Added 'ClientWebsiteBundle' to default bundles of Assetic configuration.
+    * BUGFIX      #816  [SULU-STANDARD]         Added 'ClientWebsiteBundle' to default bundles of Assetic configuration.
     * ENHANCEMENT #795  [SULU-STANDARD]         Updated dependencies and fixed symfony3 deprecations
 
 * 1.5.3 (2017-04-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
-    * BUGFIX      #XXX  [SULU-STANDARD]			Added 'ClientWebsiteBundle' to default bundles of Assetic configuration.
+    * BUGFIX      #816  [SULU-STANDARD]			Added 'ClientWebsiteBundle' to default bundles of Assetic configuration.
     * ENHANCEMENT #795  [SULU-STANDARD]         Updated dependencies and fixed symfony3 deprecations
 
 * 1.5.3 (2017-04-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ CHANGELOG for Sulu CMF
 ======================
 
 * dev-develop
+	* BUGFIX      #XXX  [SULU-STANDARD]			Added 'ClientWebsiteBundle' to default bundles of Assetic configuration.
     * ENHANCEMENT #795  [SULU-STANDARD]         Updated dependencies and fixed symfony3 deprecations
 
 * 1.5.3 (2017-04-06)

--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -40,7 +40,7 @@ twig:
 assetic:
     debug:          "%kernel.debug%"
     use_controller: false
-    bundles:        [ ]
+    bundles:        ['ClientWebsiteBundle']
     #java: /usr/bin/java
     filters:
         cssrewrite: ~

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "symfony/polyfill-apcu": "~1.0",
         "sensio/distribution-bundle": "~5.0",
         "incenteev/composer-parameter-handler": "~2.0",
+		"sulu/document-manager": "@dev",
         "sulu/sulu": "dev-develop as 1.5.0",
         "dantleech/phpcr-migrations-bundle": "~1.0",
         "sulu/theme-bundle": "~1.2",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/polyfill-apcu": "~1.0",
         "sensio/distribution-bundle": "~5.0",
         "incenteev/composer-parameter-handler": "~2.0",
-		"sulu/document-manager": "@dev",
+        "sulu/document-manager": "@dev",
         "sulu/sulu": "dev-develop as 1.5.0",
         "dantleech/phpcr-migrations-bundle": "~1.0",
         "sulu/theme-bundle": "~1.2",


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT
| Documentation PR | sulu-io/sulu-docs#prnum

#### What's in this PR?

Added ClientWebsiteBundle to Assetic configuration and sulu/document-manager to composer.json.

#### Why?

`composer install` on branch develop did not work (missing dependecy sulu/document-manager).
`app/console assetic:dump` did not include the ClientWebsiteBundle, which is delivered along the sulu/sulu-standard repository.

- Fixed Assetic dump to include the sulu-standard bundle 'ClientWebsiteBundle'.
- Fixed the composer.json file to include the sulu/document-manger as a dependency.

#### To Do

- [ ] Create a documentation PR
