### PR TITLE
fix conflict of admin and website session cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu CMF
 ======================
 
+* dev-master
+    * HOTFIX      #836                                     Fixed conflict of admin and website session cookie
+
 * 1.6.9 (2017-12-04)
     * ENHANCEMENT sulu/sulu#3665 [CategoryBundle]          Added keywords to category serialization
     * HOTFIX      sulu/sulu#3671 [CoreBundle]              Remove cache builder from sulu:build command

--- a/app/config/admin/config.yml
+++ b/app/config/admin/config.yml
@@ -4,6 +4,12 @@ imports:
     - { resource: ../config.yml }
     - { resource: ../widgets.yml }
 
+framework:
+    session:
+        cookie_path: /admin
+    fragments:
+        path: /admin/_fragments
+
 # Assetic Configuration
 assetic:
     bundles: []


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes https://github.com/sulu/sulu/issues/3680
| Related issues/PRs | https://github.com/sulu/sulu-minimal/pull/78
| License | MIT
| Documentation PR | sulu-io/sulu-docs#prnum

#### What's in this PR?

Set session cookie path and fragments path to /admin/... 

#### Why?

To avoid session and fragments conflicts with website.
