### PR TITLE
Remove deprecated apcu example in website.php and admin.php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 script: ./tests/runtests.sh
 
 php:
-    - 5.5
+    - 5.6
     - 7.0
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 script: ./tests/runtests.sh
 
 php:
-    - 5.6
+    - 5.5
     - 7.0
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu CMF
 ======================
 
+* dev-master
+    * HOTFIX      #837  [Sulu-Standard]           Remove deprecated apcu example in website.php and admin.php
+
 * 1.6.12 (2017-12-21)
     * ENHANCEMENT #3698 [ContentBundle]           SEO description length changed from 155 to 320
     * HOTFIX      #3695 [RouteBundle]             Added check for empty request format

--- a/web/admin.php
+++ b/web/admin.php
@@ -9,7 +9,6 @@
  * with this source code in the file LICENSE.
  */
 
-use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -34,16 +33,6 @@ include_once __DIR__ . '/../app/bootstrap.php.cache';
 if (SYMFONY_DEBUG) {
     Debug::enable();
 }
-
-// Enable APC for autoloading to improve performance.
-// You should change the ApcClassLoader first argument to a unique prefix
-// in order to prevent cache key conflicts with other applications
-// also using APC.
-/*
-$apcLoader = new ApcClassLoader(sha1(__FILE__), $loader);
-$loader->unregister();
-$apcLoader->register(true);
-*/
 
 $kernel = new AdminKernel(SYMFONY_ENV, SYMFONY_DEBUG);
 $kernel->loadClassCache();

--- a/web/website.php
+++ b/web/website.php
@@ -9,7 +9,6 @@
  * with this source code in the file LICENSE.
  */
 
-use Symfony\Component\ClassLoader\ApcClassLoader;
 use Symfony\Component\Debug\Debug;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -34,14 +33,6 @@ include_once __DIR__ . '/../app/bootstrap.php.cache';
 if (SYMFONY_DEBUG) {
     Debug::enable();
 }
-
-// Use APC for autoloading to improve performance.
-// Change 'sf2' to a unique prefix in order to prevent cache key conflicts
-// with other applications also using APC.
-//
-// $apcLoader = new ApcClassLoader('sf2', $loader);
-// $loader->unregister();
-// $apcLoader->register(true);
 
 $kernel = new WebsiteKernel(SYMFONY_ENV, SYMFONY_DEBUG);
 $kernel->loadClassCache();


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Remove deprecated apcu example in admin.php and website.php.

#### Why?

It can end in strange errors when use the new recommended way over composer `composer install --apcu-autoloader`.

#### Example Usage

~~~bash
composer install --apcu-autoloader
~~~

