### PR TITLE
Fix home type in example webspace

### DIFF
--- a/app/Resources/webspaces/sulu.io.xml.dist
+++ b/app/Resources/webspaces/sulu.io.xml.dist
@@ -15,7 +15,7 @@
 
     <default-templates>
         <default-template type="page">default</default-template>
-        <default-template type="homepage">overview</default-template>
+        <default-template type="home">overview</default-template>
     </default-templates>
 
     <templates>


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Fixed tickets | fixes #issuenum
| Related issues/PRs | #issuenum
| License | MIT

#### What's in this PR?

Rename startpage type from homepage to new home.

#### Why?

It throws an error in the webspace validate command as the type is not found.

#### Example Usage

```bash
app/console sulu:content:validate:webspaces
```

