### PR TITLE
Fix compatibility with php 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,14 @@ env:
 
 script: ./tests/runtests.sh
 
-php:
-    - 5.5
-    - 7.0
+matrix:
+  include:
+    - php: 5.5
+      env:
+        - COMPOSER_FLAGS="--prefer-dist --no-interaction --prefer-lowest"
+    - php: 7.0
+      env:
+        - COMPOSER_FLAGS="--prefer-dist --no-interaction"
 
 before_script:
     - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ php:
     - 7.0
 
 before_script:
-    - echo "memory_limit=2048M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    - echo "memory_limit=4096M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - ./tests/beforetests.sh
 
 after_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu CMF
 ======================
 
+* dev-master
+    * HOTFIX      sulu/sulu-standard#856  [Sulu-Standard]           Fix compatibility with php 5.5
+
 * 1.6.20 (2018-06-29)
     * BUGFIX      sulu/sulu#4042 [AudienceTargetingBundle] Add symfony 3.4.12 as conflict to fix caching tests
     * HOTFIX      sulu/sulu#4019 [Component]               Fix handling of authored date on safari
@@ -271,7 +274,6 @@ CHANGELOG for Sulu CMF
     * FEATURE     sulu/sulu#3816 [All]                   Validate if grunt build was run for all bundles with circleci
     * BUGFIX      sulu/sulu#3806 [All]                   Fix compatibility on lowest and fix appveyor
     * BUGFIX      sulu/sulu#3351 [ContentBundle]         Fix spacing between rows and section in content template generation
->>>>>>> 397593ad7f3ea56e5f77b2522516f682dd01667f
 
 * 1.5.11 (2018-02-27)
     * HOTFIX      sulu/sulu-standard#844 [SULU-STANDARD] Fix home type in example webspace

--- a/app/AbstractKernel.php
+++ b/app/AbstractKernel.php
@@ -83,7 +83,10 @@ abstract class AbstractKernel extends SuluKernel
             $bundles[] = new Symfony\Bundle\WebProfilerBundle\WebProfilerBundle();
             $bundles[] = new Sensio\Bundle\DistributionBundle\SensioDistributionBundle();
             $bundles[] = new Sensio\Bundle\GeneratorBundle\SensioGeneratorBundle();
-            $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
+
+            if (class_exists('Symfony\Bundle\WebServerBundle\WebServerBundle')) {
+                $bundles[] = new Symfony\Bundle\WebServerBundle\WebServerBundle();
+            }
 
             // debug enhancement
             $bundles[] = new Sulu\Bundle\TestBundle\SuluTestBundle();

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": "^5.5.9 || ~7.0",
-        "symfony/symfony": "^3.3",
+        "symfony/symfony": "^2.8.7 ||  ^3.0",
         "symfony/monolog-bundle": "^2.8.7 || ^3.0",
         "symfony/polyfill-apcu": "~1.0",
         "sensio/distribution-bundle": "~5.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/monolog-bundle": "^2.8.7 || ^3.0",
         "symfony/polyfill-apcu": "~1.0",
         "sensio/distribution-bundle": "~5.0",
-        "incenteev/composer-parameter-handler": "~2.0",
+        "incenteev/composer-parameter-handler": "~2.1",
         "sulu/sulu": "~1.6.0",
         "dantleech/phpcr-migrations-bundle": "~1.0",
         "sulu/theme-bundle": "~1.3.1",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/symfony": "^2.8.7 ||  ^3.0",
         "symfony/monolog-bundle": "^2.8.7 || ^3.0",
         "symfony/polyfill-apcu": "~1.0",
-        "sensio/distribution-bundle": "~5.0",
+        "sensio/distribution-bundle": "~5.0.6",
         "incenteev/composer-parameter-handler": "~2.1",
         "sulu/sulu": "~1.6.0",
         "dantleech/phpcr-migrations-bundle": "~1.0",

--- a/tests/beforetests.sh
+++ b/tests/beforetests.sh
@@ -31,7 +31,7 @@ mkdir -p $LOGS_DIR
 composer selfupdate
 
 # FIXME hack for prefer-lowest bug: https://github.com/composer/composer/issues/7161
-if [[ $COMPOSER_FLAGS == *"--prefer-lowest"* ]]; then composer install fi
+if [[ $COMPOSER_FLAGS == *"--prefer-lowest"* ]]; then composer install; fi
 
 composer update $COMPOSER_FLAGS
 cp app/Resources/webspaces/sulu.io.xml.dist app/Resources/webspaces/sulu.io.xml

--- a/tests/beforetests.sh
+++ b/tests/beforetests.sh
@@ -29,7 +29,11 @@ sudo service apache2 restart
 
 mkdir -p $LOGS_DIR
 composer selfupdate
-composer update --no-interaction $COMPOSER_FLAGS
+
+# FIXME hack for prefer-lowest bug: https://github.com/composer/composer/issues/7161
+if [[ $COMPOSER_FLAGS == *"--prefer-lowest"* ]]; then composer install fi
+
+composer update $COMPOSER_FLAGS
 cp app/Resources/webspaces/sulu.io.xml.dist app/Resources/webspaces/sulu.io.xml
 cp app/Resources/pages/overview.xml.dist app/Resources/pages/overview.xml
 cp app/Resources/pages/default.xml.dist app/Resources/pages/default.xml

--- a/tests/beforetests.sh
+++ b/tests/beforetests.sh
@@ -29,7 +29,7 @@ sudo service apache2 restart
 
 mkdir -p $LOGS_DIR
 composer selfupdate
-composer update --no-interaction
+composer update --no-interaction $COMPOSER_FLAGS
 cp app/Resources/webspaces/sulu.io.xml.dist app/Resources/webspaces/sulu.io.xml
 cp app/Resources/pages/overview.xml.dist app/Resources/pages/overview.xml
 cp app/Resources/pages/default.xml.dist app/Resources/pages/default.xml


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| License | MIT

#### What's in this PR?

Allow symfony 2.8 and check if web server bundle exists.

#### Why?

Fix the compatibility with php 5.5 

#### Example Usage

~~~php
php55 /usr/local/bin/composer install
~~~

