### PR TITLE
Fixes that test environment write into same index as live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG for Sulu CMF
 ======================
 
+* dev-master
+    * HOTFIX      #849  [Sulu-Standard]         Fix that test environment write into same index as live
+
 * 1.6.22 (2018-10-05)
     * HOTFIX      #4146 [PreviewBundle]         Fixed preview render preview attribute and XmlHttpRequest state
     * BUGFIX      #4121 [HttpCache]             Set a timeout when purging caches

--- a/app/config/admin/config_test.yml
+++ b/app/config/admin/config_test.yml
@@ -21,3 +21,7 @@ doctrine:
         dbname: sulu_test
         user: root
         password:
+
+massive_search:
+    metadata:
+        prefix: test

--- a/app/config/website/config_test.yml
+++ b/app/config/website/config_test.yml
@@ -21,3 +21,7 @@ doctrine:
         dbname: sulu_test
         user: root
         password:
+
+massive_search:
+    metadata:
+        prefix: test


### PR DESCRIPTION
| Q | A
| --- | ---
| Bug fix? | yes
| New feature? | no
| BC breaks? | no
| Deprecations? | no
| Realted PRs? | https://github.com/sulu/sulu-minimal/pull/109
| License | MIT

#### What's in this PR?

Set the massive_search_prefix to `test` in test environment.

#### Why?

Currently the test write into the same index as the other environment which should be avoided.

#### Example Usage

~~~php
SYMFONY_ENV=test bin/simple-phpunit
~~~

